### PR TITLE
44 use extrenal ai api as model source

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ To run the project, run the following command:
 java -jar target/CivicSage-0.0.1-SNAPSHOT.jar
 ```
 
+## Running the project
+
+In order to use the application you need to provide a configuration to access a LLM. Our recommended approach during
+development is to use [Docker Model Runner](https://docs.docker.com/ai/model-runner/) (DMR). But you may also provide
+the configuration for openAI or any other platform that provides a openAI like API.
+
 ## OpenAPI
 
 This project uses OpenAPI to document the API and generate the server code.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ java -jar target/CivicSage-0.0.1-SNAPSHOT.jar
 
 In order to use the application you need to provide a configuration to access a LLM. Our recommended approach during
 development is to use [Docker Model Runner](https://docs.docker.com/ai/model-runner/) (DMR). But you may also provide
-the configuration for openAI or any other platform that provides a openAI like API.
+the configuration for openAI or any other platform that provides a openAI like API. The default model to use is
+currently `ai/mxbai-embed-large`. Please provide it via `docker model pull ai/mxbai-embed-large`.
 
 ## OpenAPI
 
@@ -50,16 +51,13 @@ While the project is running, you can access the Swagger UI at http://localhost:
 
 ## Configuring the EmbeddingModel
 
-To embed text, this project uses the `EmbeddingModel` interface from Spring AI.
-By default, it uses the `TransformersEmbeddingModel`
-[(documentation)](https://docs.spring.io/spring-ai/reference/api/embeddings/onnx.html) implementation,
-which requires a model URI and a tokenizer URI.
-You can configure these properties in your `application.properties` file.
+Prior versions did host the embedding model within this application. For better scaling the LLM has been separated into
+a separate source. Setting up the model is not scope of this project. For development, we recommend the usage of Docker
+Model Runner. For production, a separate service should be used, self-hosted or from a cloud provider. Configuring the
+model is done using the following properties:
 
 ```properties
-spring.ai.embedding.transformer.onnx.modelUri=https://example.com/model.onnx
-spring.ai.embedding.transformer.tokenizer.uri=https://example.com/tokenizer.json
+spring.ai.openai.embedding.options.model=ai/mxbai-embed-large
+spring.ai.openai.base-url=http://localhost:12434/engines
+spring.ai.openai.api-key=test
 ```
-
-Spring AI has a default model URI and tokenizer URI that you can use for testing purposes.
-The model is downloaded at startup and cached for subsequent runs.

--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-starter-model-transformers</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-starter-vector-store-pgvector</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,10 @@
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-starter-vector-store-pgvector</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-openai</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,8 @@ spring.ai.vectorstore.pgvector.distance-type=COSINE_DISTANCE
 spring.ai.vectorstore.pgvector.max-document-batch-size=10000
 spring.ai.vectorstore.pgvector.initialize-schema=true
 security.allowed-origins=*
+# https://docs.spring.io/spring-ai/reference/api/chat/dmr-chat.html
+spring.ai.openai.base-url=http://localhost:12434/engines
+spring.ai.openai.api-key=test
+spring.ai.model.embedding=openai
+spring.ai.openai.embedding.options.model=ai/mxbai-embed-large


### PR DESCRIPTION
This makes it easier to separate the LLM from the API. Deployment will be easier for the separated concerns.