### PR TITLE
11 prevent duplicate embeddings

### DIFF
--- a/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package de.uol.pgdoener.civicsage;
 
 import de.uol.pgdoener.civicsage.index.exception.ReadFileException;
 import de.uol.pgdoener.civicsage.index.exception.ReadUrlException;
+import de.uol.pgdoener.civicsage.index.exception.StorageException;
 import de.uol.pgdoener.civicsage.search.exception.NotEnoughResultsAvailableException;
 import de.uol.pgdoener.civicsage.source.exception.HashingException;
 import de.uol.pgdoener.civicsage.source.exception.SourceCollisionException;
@@ -24,6 +25,13 @@ import java.util.Map;
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(StorageException.class)
+    public ResponseEntity<Object> handleStorageException(StorageException ex) {
+        ErrorResponse errorResponse = ErrorResponse.create(ex, HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+        log.debug("StorageException: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse.getBody());
+    }
 
     @ExceptionHandler(HashingException.class)
     public ResponseEntity<Object> handleHashingException(HashingException ex) {

--- a/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package de.uol.pgdoener.civicsage;
 import de.uol.pgdoener.civicsage.index.exception.ReadFileException;
 import de.uol.pgdoener.civicsage.index.exception.ReadUrlException;
 import de.uol.pgdoener.civicsage.search.exception.NotEnoughResultsAvailableException;
+import de.uol.pgdoener.civicsage.source.exception.SourceCollisionException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -21,6 +22,13 @@ import java.util.Map;
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(SourceCollisionException.class)
+    public ResponseEntity<Object> handleSourceCollisionException(SourceCollisionException ex) {
+        ErrorResponse errorResponse = ErrorResponse.create(ex, HttpStatus.CONFLICT, ex.getMessage());
+        log.debug("SourceCollisionException: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse.getBody());
+    }
 
     @ExceptionHandler(NotEnoughResultsAvailableException.class)
     public ResponseEntity<Object> handleNotEnoughResultsAvailableException(NotEnoughResultsAvailableException ex) {

--- a/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package de.uol.pgdoener.civicsage;
 import de.uol.pgdoener.civicsage.index.exception.ReadFileException;
 import de.uol.pgdoener.civicsage.index.exception.ReadUrlException;
 import de.uol.pgdoener.civicsage.search.exception.NotEnoughResultsAvailableException;
+import de.uol.pgdoener.civicsage.source.exception.HashingException;
 import de.uol.pgdoener.civicsage.source.exception.SourceCollisionException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -22,6 +23,13 @@ import java.util.Map;
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(HashingException.class)
+    public ResponseEntity<Object> handleHashingException(HashingException ex) {
+        ErrorResponse errorResponse = ErrorResponse.create(ex, HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+        log.debug("HashingException: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse.getBody());
+    }
 
     @ExceptionHandler(SourceCollisionException.class)
     public ResponseEntity<Object> handleSourceCollisionException(SourceCollisionException ex) {

--- a/src/main/java/de/uol/pgdoener/civicsage/api/controller/IndexController.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/api/controller/IndexController.java
@@ -3,20 +3,14 @@ package de.uol.pgdoener.civicsage.api.controller;
 import de.uol.pgdoener.civicsage.api.IndexApi;
 import de.uol.pgdoener.civicsage.business.dto.IndexWebsiteRequestDto;
 import de.uol.pgdoener.civicsage.index.IndexService;
-import de.uol.pgdoener.civicsage.source.FileSource;
-import de.uol.pgdoener.civicsage.source.SourceService;
-import de.uol.pgdoener.civicsage.storage.StorageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
 
 @Slf4j
 @Controller
@@ -24,28 +18,14 @@ import java.util.UUID;
 public class IndexController implements IndexApi {
 
     private final IndexService indexService;
-    private final StorageService storageService;
-    private final SourceService sourceService;
 
-    // TODO move logic to a service
     @Override
     public ResponseEntity<Void> indexFiles(List<MultipartFile> files, Map<String, String> additionalMetadata) {
         log.info("Received {} files to index", files.size());
         for (MultipartFile file : files) {
-            Optional<UUID> objectID = Optional.empty();
-            try {
-                objectID = storageService.store(file.getInputStream());
-                log.info("Stored file {}", file.getOriginalFilename());
-            } catch (IOException e) {
-                log.error("Error storing file {}", file.getOriginalFilename(), e);
-                continue;
-            }
-            if (objectID.isPresent()) {
-                log.info("Indexing file {}", file.getOriginalFilename());
-                indexService.indexFile(file, objectID.get());
-                log.info("File {} indexed successfully", file.getOriginalFilename());
-            }
-
+            log.info("Indexing file {}", file.getOriginalFilename());
+            indexService.indexFile(file);
+            log.info("File {} indexed successfully", file.getOriginalFilename());
         }
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/de/uol/pgdoener/civicsage/api/controller/IndexController.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/api/controller/IndexController.java
@@ -41,7 +41,6 @@ public class IndexController implements IndexApi {
                 continue;
             }
             if (objectID.isPresent()) {
-                sourceService.save(new FileSource(objectID.get(), file.getOriginalFilename()));
                 log.info("Indexing file {}", file.getOriginalFilename());
                 indexService.indexFile(file, objectID.get());
                 log.info("File {} indexed successfully", file.getOriginalFilename());

--- a/src/main/java/de/uol/pgdoener/civicsage/index/IndexService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/IndexService.java
@@ -48,6 +48,7 @@ public class IndexService {
 
     public void indexURL(IndexWebsiteRequestDto indexWebsiteRequestDto) {
         String url = indexWebsiteRequestDto.getUrl();
+        url = normalizeURL(url);
         sourceService.verifyWebsiteNotIndexed(url);
 
         List<Document> documents = documentReaderService.readURL(url);
@@ -57,6 +58,20 @@ public class IndexService {
 
         embeddingService.save(documents);
         sourceService.save(new WebsiteSource(null, url));
+    }
+
+    public String normalizeURL(String url) {
+        // make sure url starts with a protocol
+        if (!url.matches("^[a-z]+://.+")) {
+            url = "https://" + url;
+        }
+
+        // make sure there is no trailing slash "/"
+        if (url.endsWith("/")) {
+            url = url.substring(0, url.length() - 1);
+        }
+
+        return url;
     }
 
     private List<Document> postProcessDocuments(List<Document> documents) {

--- a/src/main/java/de/uol/pgdoener/civicsage/index/IndexService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/IndexService.java
@@ -33,7 +33,8 @@ public class IndexService {
     private final FileHashingService fileHashingService;
 
     public void indexFile(@NonNull MultipartFile file, UUID objectId) {
-        sourceService.verifyFileNotIndexed(file);
+        String hash = fileHashingService.hash(file);
+        sourceService.verifyFileHashNotIndexed(hash);
 
         List<Document> documents = documentReaderService.read(file);
         log.debug("Read {} documents from file: {}", documents.size(), file.getOriginalFilename());
@@ -42,7 +43,6 @@ public class IndexService {
         documents.forEach(document -> document.getMetadata().put(FILE_ID, objectId));
 
         embeddingService.save(documents);
-        String hash = fileHashingService.hash(file);
         sourceService.save(new FileSource(objectId, file.getOriginalFilename(), hash));
     }
 

--- a/src/main/java/de/uol/pgdoener/civicsage/index/IndexService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/IndexService.java
@@ -3,6 +3,8 @@ package de.uol.pgdoener.civicsage.index;
 import de.uol.pgdoener.civicsage.business.dto.IndexWebsiteRequestDto;
 import de.uol.pgdoener.civicsage.embedding.EmbeddingService;
 import de.uol.pgdoener.civicsage.index.document.DocumentReaderService;
+import de.uol.pgdoener.civicsage.source.SourceService;
+import de.uol.pgdoener.civicsage.source.WebsiteSource;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +23,7 @@ import static de.uol.pgdoener.civicsage.index.document.MetadataKeys.FILE_ID;
 @RequiredArgsConstructor
 public class IndexService {
 
+    private final SourceService sourceService;
     private final DocumentReaderService documentReaderService;
     private final SemanticSplitterService semanticSplitterService;
     private final EmbeddingService embeddingService;
@@ -38,6 +41,7 @@ public class IndexService {
 
     public void indexURL(IndexWebsiteRequestDto indexWebsiteRequestDto) {
         String url = indexWebsiteRequestDto.getUrl();
+        sourceService.verifyWebsiteNotIndexed(url);
 
         List<Document> documents = documentReaderService.readURL(url);
         log.debug("Read {} documents from url: {}", documents.size(), url);
@@ -45,6 +49,7 @@ public class IndexService {
         documents = postProcessDocuments(documents);
 
         embeddingService.save(documents);
+        sourceService.save(new WebsiteSource(null, url));
     }
 
     private List<Document> postProcessDocuments(List<Document> documents) {

--- a/src/main/java/de/uol/pgdoener/civicsage/index/document/DocumentReaderService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/document/DocumentReaderService.java
@@ -30,14 +30,10 @@ public class DocumentReaderService {
     }
 
     public List<Document> readURL(String url) {
-        // make sure url starts with http(s)://
-        if (url.matches("^[a-z]+://.+")) {
-            //noinspection HttpUrlsUsage
-            if (!(url.startsWith("http://") || url.startsWith("https://"))) {
-                throw new ReadUrlException("Invalid protocol used in URL: " + url);
-            }
-        } else {
-            url = "https://" + url;
+        // can only read urls using HTTP(S)
+        //noinspection HttpUrlsUsage
+        if (!(url.startsWith("http://") || url.startsWith("https://"))) {
+            throw new ReadUrlException("Invalid protocol used in URL: " + url);
         }
 
         DocumentReader documentReader = documentReaderFactory.createForURL(url);

--- a/src/main/java/de/uol/pgdoener/civicsage/index/exception/StorageException.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/exception/StorageException.java
@@ -1,0 +1,13 @@
+package de.uol.pgdoener.civicsage.index.exception;
+
+public class StorageException extends RuntimeException {
+
+    public StorageException(String message) {
+        super(message);
+    }
+
+    public StorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/de/uol/pgdoener/civicsage/source/FileHashingService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/source/FileHashingService.java
@@ -1,0 +1,43 @@
+package de.uol.pgdoener.civicsage.source;
+
+import de.uol.pgdoener.civicsage.index.exception.ReadFileException;
+import de.uol.pgdoener.civicsage.source.exception.HashingException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+@Slf4j
+@Service
+public class FileHashingService {
+
+    private static final String ALGORITHM = "SHA-256";
+
+    public String hash(MultipartFile file) {
+        try {
+            return hashInternal(file);
+        } catch (NoSuchAlgorithmException e) {
+            log.error("Error while hashing file: ", e);
+            throw new HashingException("Hashing algorithm exception", e);
+        } catch (IOException e) {
+            log.warn("Could not read file while hashing", e);
+            throw new ReadFileException("Could not read file while hashing", e);
+        }
+    }
+
+    private String hashInternal(MultipartFile file) throws NoSuchAlgorithmException, IOException {
+        MessageDigest digest = MessageDigest.getInstance(ALGORITHM);
+        try (var digestIn = new DigestInputStream(file.getInputStream(), digest)) {
+            digestIn.readAllBytes();
+        }
+        String hash = HexFormat.of().formatHex(digest.digest());
+        log.debug("Hash for file is {}", hash);
+        return hash;
+    }
+
+}

--- a/src/main/java/de/uol/pgdoener/civicsage/source/FileSource.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/source/FileSource.java
@@ -21,4 +21,7 @@ public class FileSource {
     @Column(nullable = false)
     private String fileName;
 
+    @Column(unique = true)
+    private String hash;
+
 }

--- a/src/main/java/de/uol/pgdoener/civicsage/source/FileSourceRepository.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/source/FileSourceRepository.java
@@ -9,4 +9,6 @@ import java.util.UUID;
 public interface FileSourceRepository
         extends CrudRepository<FileSource, UUID> {
 
+    boolean existsByHash(String hash);
+
 }

--- a/src/main/java/de/uol/pgdoener/civicsage/source/SourceService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/source/SourceService.java
@@ -1,5 +1,6 @@
 package de.uol.pgdoener.civicsage.source;
 
+import de.uol.pgdoener.civicsage.source.exception.SourceCollisionException;
 import de.uol.pgdoener.civicsage.source.exception.SourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,9 +15,14 @@ import java.util.UUID;
 public class SourceService {
 
     private final FileSourceRepository fileSourceRepository;
+    private final WebsiteSourceRepository websiteSourceRepository;
 
     public void save(FileSource fileSource) {
         fileSourceRepository.save(fileSource);
+    }
+
+    public void save(WebsiteSource websiteSource) {
+        websiteSourceRepository.save(websiteSource);
     }
 
     public FileSource getFileSourceById(UUID id) {
@@ -24,6 +30,12 @@ public class SourceService {
         if (optionalFileSource.isEmpty())
             throw new SourceNotFoundException("Could not find source with id +" + id);
         return optionalFileSource.get();
+    }
+
+    public void verifyWebsiteNotIndexed(String url) {
+        if (websiteSourceRepository.existsByUrl(url)) {
+            throw new SourceCollisionException("Website is already indexed");
+        }
     }
 
 }

--- a/src/main/java/de/uol/pgdoener/civicsage/source/SourceService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/source/SourceService.java
@@ -5,7 +5,6 @@ import de.uol.pgdoener.civicsage.source.exception.SourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -40,8 +39,7 @@ public class SourceService {
         }
     }
 
-    public void verifyFileNotIndexed(MultipartFile file) {
-        String hash = fileHashingService.hash(file);
+    public void verifyFileHashNotIndexed(String hash) {
         if (fileSourceRepository.existsByHash(hash)) {
             throw new SourceCollisionException("File is already indexed");
         }

--- a/src/main/java/de/uol/pgdoener/civicsage/source/SourceService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/source/SourceService.java
@@ -5,6 +5,7 @@ import de.uol.pgdoener.civicsage.source.exception.SourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -16,6 +17,7 @@ public class SourceService {
 
     private final FileSourceRepository fileSourceRepository;
     private final WebsiteSourceRepository websiteSourceRepository;
+    private final FileHashingService fileHashingService;
 
     public void save(FileSource fileSource) {
         fileSourceRepository.save(fileSource);
@@ -35,6 +37,13 @@ public class SourceService {
     public void verifyWebsiteNotIndexed(String url) {
         if (websiteSourceRepository.existsByUrl(url)) {
             throw new SourceCollisionException("Website is already indexed");
+        }
+    }
+
+    public void verifyFileNotIndexed(MultipartFile file) {
+        String hash = fileHashingService.hash(file);
+        if (fileSourceRepository.existsByHash(hash)) {
+            throw new SourceCollisionException("File is already indexed");
         }
     }
 

--- a/src/main/java/de/uol/pgdoener/civicsage/source/WebsiteSource.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/source/WebsiteSource.java
@@ -1,0 +1,26 @@
+package de.uol.pgdoener.civicsage.source;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class WebsiteSource {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @Column(columnDefinition = "TEXT")
+    private String url;
+
+}

--- a/src/main/java/de/uol/pgdoener/civicsage/source/WebsiteSource.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/source/WebsiteSource.java
@@ -20,7 +20,7 @@ public class WebsiteSource {
     @GeneratedValue
     private UUID id;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", unique = true)
     private String url;
 
 }

--- a/src/main/java/de/uol/pgdoener/civicsage/source/WebsiteSourceRepository.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/source/WebsiteSourceRepository.java
@@ -1,0 +1,14 @@
+package de.uol.pgdoener.civicsage.source;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface WebsiteSourceRepository
+        extends CrudRepository<WebsiteSource, UUID> {
+
+    boolean existsByUrl(String url);
+
+}

--- a/src/main/java/de/uol/pgdoener/civicsage/source/exception/HashingException.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/source/exception/HashingException.java
@@ -1,0 +1,13 @@
+package de.uol.pgdoener.civicsage.source.exception;
+
+public class HashingException extends RuntimeException {
+
+    public HashingException(String message) {
+        super(message);
+    }
+
+    public HashingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/de/uol/pgdoener/civicsage/source/exception/SourceCollisionException.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/source/exception/SourceCollisionException.java
@@ -1,0 +1,9 @@
+package de.uol.pgdoener.civicsage.source.exception;
+
+public class SourceCollisionException extends RuntimeException {
+
+    public SourceCollisionException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
This PR prevents duplicate embeddings of websites and files.

Websites are identified via their URL. Files via their hash using the SHA-256 algorithm.

TODO
- [x] normalize URLs before using them
- [x] avoid hashing files twice

I am also not happy with the general structure of indexing. I am not sure what the best strategy would be.