### PR TITLE
69 searchquery filtering

### DIFF
--- a/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import de.uol.pgdoener.civicsage.embedding.exception.DocumentNotFoundException;
 import de.uol.pgdoener.civicsage.index.exception.ReadFileException;
 import de.uol.pgdoener.civicsage.index.exception.ReadUrlException;
 import de.uol.pgdoener.civicsage.index.exception.StorageException;
+import de.uol.pgdoener.civicsage.search.exception.FilterExpressionException;
 import de.uol.pgdoener.civicsage.search.exception.NotEnoughResultsAvailableException;
 import de.uol.pgdoener.civicsage.source.exception.HashingException;
 import de.uol.pgdoener.civicsage.source.exception.SourceCollisionException;
@@ -26,6 +27,13 @@ import java.util.Map;
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(FilterExpressionException.class)
+    public ResponseEntity<Object> handleFilterExpressionException(FilterExpressionException ex) {
+        ErrorResponse errorResponse = ErrorResponse.create(ex, HttpStatus.BAD_REQUEST, ex.getMessage());
+        log.debug("FilterExpressionException: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse.getBody());
+    }
 
     @ExceptionHandler(DocumentNotFoundException.class)
     public ResponseEntity<Object> handleDocumentNotFoundException(DocumentNotFoundException ex) {

--- a/src/main/java/de/uol/pgdoener/civicsage/index/document/MetadataKeys.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/document/MetadataKeys.java
@@ -7,15 +7,25 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MetadataKeys {
 
-    FILE_NAME("file_name"),
-    FILE_ID("file_id"),
-    LINE_NUMBER("line_number"),
-    START_PAGE("page_number"),
-    END_PAGE("end_page_number"),
-    TITLE("title"),
-    URL("url"),
-    ADDITIONAL_PROPERTIES("additional_properties");
+    FILE_NAME("file_name", true),
+    FILE_ID("file_id", true),
+    LINE_NUMBER("line_number", false),
+    START_PAGE("page_number", false),
+    END_PAGE("end_page_number", false),
+    TITLE("title", true),
+    URL("url", true),
+    ADDITIONAL_PROPERTIES("additional_properties", false); // this is marked as internal, but is available in filter expression using "additional_properties."
 
+    /**
+     * The key used in the metadata map stored in the {@link org.springframework.ai.vectorstore.VectorStore}
+     */
     private final String value;
+
+    /**
+     * This indicates whether this key is exposed via the api or is only used internally.
+     * If it marked as internal, it might be changed if it's use by
+     * {@link org.springframework.ai.document.DocumentReader}s has been stabilized.
+     */
+    private final boolean exposed;
 
 }

--- a/src/main/java/de/uol/pgdoener/civicsage/search/FilterExpressionValidator.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/search/FilterExpressionValidator.java
@@ -1,0 +1,56 @@
+package de.uol.pgdoener.civicsage.search;
+
+import de.uol.pgdoener.civicsage.index.document.MetadataKeys;
+import de.uol.pgdoener.civicsage.search.exception.FilterExpressionException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.vectorstore.filter.Filter;
+import org.springframework.ai.vectorstore.filter.FilterExpressionTextParser;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FilterExpressionValidator {
+
+    private static final List<String> validMetadataKeys = Arrays.stream(MetadataKeys.values())
+            .filter(MetadataKeys::isExposed)
+            .map(MetadataKeys::getValue)
+            .toList();
+
+    /**
+     * This method validates that the provided filter expression only used allowed metadata keys. If an internal
+     * metadata key is used, a {@link FilterExpressionException} is thrown. Keys for additional properties begin with
+     * the key for additional properties ({@link MetadataKeys#ADDITIONAL_PROPERTIES}) followed by a dot.
+     *
+     * @param filterString the expression to validate
+     */
+    public void validate(String filterString) {
+        Filter.Expression expression;
+        try {
+            expression = new FilterExpressionTextParser().parse(filterString);
+        } catch (Exception e) {
+            throw new FilterExpressionException("Could not parse filter expression", e);
+        }
+
+        if (!isValid(expression)) {
+            throw new FilterExpressionException("Filter expression used unsupported metadata keys. Refer to the server documentation");
+        }
+    }
+
+    private boolean isValid(Filter.Expression expression) {
+        return switch (expression.type()) {
+            case AND, OR ->
+                    isValid((Filter.Expression) expression.left()) && isValid((Filter.Expression) expression.right());
+            case EQ, GTE, GT, LT, IN, NIN, LTE, NOT, NE -> isValidMetadataKey(((Filter.Key) expression.left()).key());
+        };
+    }
+
+    private boolean isValidMetadataKey(String key) {
+        return validMetadataKeys.contains(key) || key.startsWith(MetadataKeys.ADDITIONAL_PROPERTIES.getValue() + ".");
+    }
+
+}

--- a/src/main/java/de/uol/pgdoener/civicsage/search/FilterExpressionValidator.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/search/FilterExpressionValidator.java
@@ -45,7 +45,8 @@ public class FilterExpressionValidator {
     private boolean isValid(Filter.Expression expression) {
         return switch (expression.type()) {
             case AND, OR -> isValid(expression.left()) && isValid(expression.right());
-            case EQ, GTE, GT, LT, IN, NIN, LTE, NOT, NE -> isValidMetadataKey(((Filter.Key) expression.left()).key());
+            case EQ, GTE, GT, LT, IN, NIN, LTE, NE -> isValidMetadataKey(((Filter.Key) expression.left()).key());
+            case NOT -> isValid(expression.left());
         };
     }
 

--- a/src/main/java/de/uol/pgdoener/civicsage/search/SearchResultMapper.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/search/SearchResultMapper.java
@@ -1,4 +1,4 @@
-package de.uol.pgdoener.civicsage.mapper;
+package de.uol.pgdoener.civicsage.search;
 
 import de.uol.pgdoener.civicsage.business.dto.SearchResultDto;
 import lombok.NonNull;

--- a/src/main/java/de/uol/pgdoener/civicsage/search/SearchService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/search/SearchService.java
@@ -3,7 +3,6 @@ package de.uol.pgdoener.civicsage.search;
 import de.uol.pgdoener.civicsage.business.dto.SearchQueryDto;
 import de.uol.pgdoener.civicsage.business.dto.SearchResultDto;
 import de.uol.pgdoener.civicsage.embedding.EmbeddingService;
-import de.uol.pgdoener.civicsage.mapper.SearchResultMapper;
 import de.uol.pgdoener.civicsage.search.exception.NotEnoughResultsAvailableException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/de/uol/pgdoener/civicsage/search/exception/FilterExpressionException.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/search/exception/FilterExpressionException.java
@@ -1,0 +1,17 @@
+package de.uol.pgdoener.civicsage.search.exception;
+
+/**
+ * This exception is thrown by the {@link de.uol.pgdoener.civicsage.search.FilterExpressionValidator} if the expression
+ * is invalid.
+ */
+public class FilterExpressionException extends RuntimeException {
+
+    public FilterExpressionException(String message) {
+        super(message);
+    }
+
+    public FilterExpressionException(String message, Exception e) {
+        super(message, e);
+    }
+
+}

--- a/src/test/java/de/uol/pgdoener/civicsage/mapper/SearchResultMapperTest.java
+++ b/src/test/java/de/uol/pgdoener/civicsage/mapper/SearchResultMapperTest.java
@@ -2,6 +2,7 @@ package de.uol.pgdoener.civicsage.mapper;
 
 
 import de.uol.pgdoener.civicsage.business.dto.SearchResultDto;
+import de.uol.pgdoener.civicsage.search.SearchResultMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.document.Document;
 


### PR DESCRIPTION
Filter expressions are now used when searching. To make sure that no internal metadata is leaked via the API, a validation has been added.

There is also a [tutorial](https://github.com/uol-esis/CivicSage-Backend/wiki/Filter-Expressions) in the wiki for users of the API.