### PR TITLE
70 only read main tag from websites if present

### DIFF
--- a/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
@@ -87,7 +87,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ReadUrlException.class)
     public ResponseEntity<Object> handleReadUrlException(ReadUrlException ex) {
         ErrorResponse errorResponse = ErrorResponse.create(ex, HttpStatus.BAD_REQUEST, ex.getMessage());
-        log.debug("ReadUrlException: {}", ex.getMessage());
+        log.debug("ReadUrlException", ex);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse.getBody());
     }
 

--- a/src/main/java/de/uol/pgdoener/civicsage/index/document/DocumentReaderFactory.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/document/DocumentReaderFactory.java
@@ -1,14 +1,13 @@
 package de.uol.pgdoener.civicsage.index.document;
 
 import de.uol.pgdoener.civicsage.index.document.reader.PdfDocumentReader;
+import de.uol.pgdoener.civicsage.index.document.reader.WebsiteDocumentReader;
 import de.uol.pgdoener.civicsage.index.exception.ReadFileException;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentReader;
 import org.springframework.ai.reader.TextReader;
-import org.springframework.ai.reader.jsoup.JsoupDocumentReader;
-import org.springframework.ai.reader.jsoup.config.JsoupDocumentReaderConfig;
 import org.springframework.ai.reader.markdown.MarkdownDocumentReader;
 import org.springframework.ai.reader.markdown.config.MarkdownDocumentReaderConfig;
 import org.springframework.ai.reader.tika.TikaDocumentReader;
@@ -73,10 +72,9 @@ public class DocumentReaderFactory {
     }
 
     public DocumentReader createForURL(@NonNull String url) {
-        JsoupDocumentReaderConfig config = JsoupDocumentReaderConfig.builder()
-                .additionalMetadata(URL.getValue(), url)
-                .build();
-        return new JsoupDocumentReader(url, config);
+        WebsiteDocumentReader reader = new WebsiteDocumentReader(url);
+        reader.getAdditionalMetadata().put(URL.getValue(), url);
+        return reader;
     }
 
 }

--- a/src/main/java/de/uol/pgdoener/civicsage/index/document/reader/WebsiteDocumentReader.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/document/reader/WebsiteDocumentReader.java
@@ -1,0 +1,42 @@
+package de.uol.pgdoener.civicsage.index.document.reader;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentReader;
+import org.springframework.ai.reader.jsoup.JsoupDocumentReader;
+import org.springframework.ai.reader.jsoup.config.JsoupDocumentReaderConfig;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class WebsiteDocumentReader implements DocumentReader {
+
+    private static final String MAIN_SELECTOR = "main";
+
+    private final String url;
+    @Getter
+    private final Map<String, Object> additionalMetadata = new HashMap<>();
+
+    @Override
+    public List<Document> get() {
+        JsoupDocumentReaderConfig config = JsoupDocumentReaderConfig.builder()
+                .additionalMetadata(additionalMetadata)
+                .selector(MAIN_SELECTOR)
+                .build();
+        List<Document> documents = new JsoupDocumentReader(url, config).read();
+
+        if (!documents.isEmpty()) {
+            return documents;
+        }
+
+        // Try again without the main selector
+        config = JsoupDocumentReaderConfig.builder()
+                .additionalMetadata(additionalMetadata)
+                .build();
+        return new JsoupDocumentReader(url, config).read();
+    }
+
+}

--- a/src/main/java/de/uol/pgdoener/civicsage/index/document/reader/WebsiteDocumentReader.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/document/reader/WebsiteDocumentReader.java
@@ -28,7 +28,7 @@ public class WebsiteDocumentReader implements DocumentReader {
                 .build();
         List<Document> documents = new JsoupDocumentReader(url, config).read();
 
-        if (!documents.isEmpty()) {
+        if (areValid(documents)) {
             return documents;
         }
 
@@ -37,6 +37,14 @@ public class WebsiteDocumentReader implements DocumentReader {
                 .additionalMetadata(additionalMetadata)
                 .build();
         return new JsoupDocumentReader(url, config).read();
+    }
+
+    private boolean areValid(List<Document> documents) {
+        return documents.stream()
+                .anyMatch(d -> {
+                    String text = d.getText();
+                    return text != null && !text.isBlank();
+                });
     }
 
 }

--- a/src/main/java/de/uol/pgdoener/civicsage/index/document/reader/WebsiteDocumentReader.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/document/reader/WebsiteDocumentReader.java
@@ -41,7 +41,7 @@ public class WebsiteDocumentReader implements DocumentReader {
 
     private boolean areValid(List<Document> documents) {
         return documents.stream()
-                .anyMatch(d -> {
+                .allMatch(d -> {
                     String text = d.getText();
                     return text != null && !text.isBlank();
                 });


### PR DESCRIPTION
This changes the indexing of websites to prefer using only elements in the `main` tag. If no elements are found it falls back to the default `body` tag.

Created #88 to handle some failures when reading URLs.