### PR TITLE
Avoid request timeouts when indexing

### DIFF
--- a/src/main/java/de/uol/pgdoener/civicsage/api/controller/IndexController.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/api/controller/IndexController.java
@@ -1,6 +1,7 @@
 package de.uol.pgdoener.civicsage.api.controller;
 
 import de.uol.pgdoener.civicsage.api.IndexApi;
+import de.uol.pgdoener.civicsage.autoconfigure.ServerProperties;
 import de.uol.pgdoener.civicsage.business.dto.IndexFilesRequestInnerDto;
 import de.uol.pgdoener.civicsage.business.dto.IndexWebsiteRequestDto;
 import de.uol.pgdoener.civicsage.index.IndexService;
@@ -10,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 import java.util.List;
+import java.util.concurrent.*;
 
 @Slf4j
 @Controller
@@ -17,24 +19,49 @@ import java.util.List;
 public class IndexController implements IndexApi {
 
     private final IndexService indexService;
+    private final ServerProperties serverProperties;
+    private final ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
 
     @Override
     public ResponseEntity<Void> indexFiles(List<IndexFilesRequestInnerDto> requests) {
-        log.info("Received {} files to index", requests.size());
-        for (IndexFilesRequestInnerDto request : requests) {
-            log.info("Indexing file {}", request.getName());
-            indexService.indexFile(request);
-            log.info("File {} indexed successfully", request.getName());
-        }
-        return ResponseEntity.ok().build();
+        CompletableFuture<ResponseEntity<Void>> future = CompletableFuture.supplyAsync(() -> {
+            log.info("Received {} files to index", requests.size());
+            for (IndexFilesRequestInnerDto request : requests) {
+                log.info("Indexing file {}", request.getName());
+                indexService.indexFile(request);
+                log.info("File {} indexed successfully", request.getName());
+            }
+            return ResponseEntity.ok().build();
+        }, executorService);
+
+        return handleFuture(future);
     }
 
     @Override
     public ResponseEntity<Void> indexWebsite(IndexWebsiteRequestDto indexWebsiteRequestDto) {
-        log.info("Indexing website {}", indexWebsiteRequestDto.getUrl());
-        indexService.indexURL(indexWebsiteRequestDto);
-        log.info("Website {} indexed successfully", indexWebsiteRequestDto.getUrl());
-        return ResponseEntity.ok().build();
+        CompletableFuture<ResponseEntity<Void>> future = CompletableFuture.supplyAsync(() -> {
+            log.info("Indexing website {}", indexWebsiteRequestDto.getUrl());
+            indexService.indexURL(indexWebsiteRequestDto);
+            log.info("Website {} indexed successfully", indexWebsiteRequestDto.getUrl());
+            return ResponseEntity.ok().build();
+        }, executorService);
+
+        return handleFuture(future);
+    }
+
+    private ResponseEntity<Void> handleFuture(CompletableFuture<ResponseEntity<Void>> future) {
+        try {
+            return future.get(serverProperties.getIndexRequestTimeout(), TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            return ResponseEntity.accepted().build();
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException re) throw re;
+            else throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/src/main/java/de/uol/pgdoener/civicsage/autoconfigure/ServerProperties.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/autoconfigure/ServerProperties.java
@@ -1,0 +1,15 @@
+package de.uol.pgdoener.civicsage.autoconfigure;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "civicsage.server")
+public class ServerProperties {
+
+    /**
+     * Timeout in milliseconds for index requests.
+     */
+    private long indexRequestTimeout = 30_000;
+
+}


### PR DESCRIPTION
The indexing is now done in a separate thread and waited for with a timeout. This timeout is not equal to the actual request timeout and should be below that to account for the overhead of the request handling. Processing of requests is wrapped in a `CompletableFuture` and given to a `VirtualThreadPerTaskExecutor` for execution. The `ExecutorService` used could be moved to a more general location, if it should be used by other components as well.

The timeout can be changed via properties.

If the future times out, 202 Accepted is returned. Otherwise, a normal 200 is returned. This has the effect, that the documents are not immediately available when searching.

It is also assumed, that when a timeout occurs, the request only has to finish embedding the documents. All errors when reading the sources should be thrown before.

Alternative:

Spring provides the classes `DeferredResult` and `WebAsyncTask`. Those classes provide functionality to return different responses, if the task times out or throws exceptions. Apparently, the executing thread is interrupted upon timout. Thus, the creation of embeddings is interrupted causing the task to fail. Thus, if we want to use those classes, we have to wrap the execution in our own thread like in the provided solution to avoid the interrupt.

There is also another problem. When using the mentioned classes, the `ResponseEntity` is wrapped in them. Thus, the method signature changes. The OpenAPI Generator supports that. However, there is only one flag for it, and it changes the signature for all endpoints.