### PR TITLE
Give feedback if sources don't have enough content

### DIFF
--- a/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package de.uol.pgdoener.civicsage;
 import de.uol.pgdoener.civicsage.embedding.exception.DocumentNotFoundException;
 import de.uol.pgdoener.civicsage.index.exception.ReadFileException;
 import de.uol.pgdoener.civicsage.index.exception.ReadUrlException;
+import de.uol.pgdoener.civicsage.index.exception.SplittingException;
 import de.uol.pgdoener.civicsage.index.exception.StorageException;
 import de.uol.pgdoener.civicsage.search.exception.FilterExpressionException;
 import de.uol.pgdoener.civicsage.search.exception.NotEnoughResultsAvailableException;
@@ -27,6 +28,13 @@ import java.util.Map;
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(SplittingException.class)
+    public ResponseEntity<Object> handleSplittingException(SplittingException ex) {
+        ErrorResponse errorResponse = ErrorResponse.create(ex, HttpStatus.BAD_REQUEST, ex.getMessage());
+        log.debug("SplittingException: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse.getBody());
+    }
 
     @ExceptionHandler(FilterExpressionException.class)
     public ResponseEntity<Object> handleFilterExpressionException(FilterExpressionException ex) {

--- a/src/main/java/de/uol/pgdoener/civicsage/index/IndexService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/IndexService.java
@@ -4,6 +4,7 @@ import de.uol.pgdoener.civicsage.business.dto.IndexFilesRequestInnerDto;
 import de.uol.pgdoener.civicsage.business.dto.IndexWebsiteRequestDto;
 import de.uol.pgdoener.civicsage.embedding.EmbeddingService;
 import de.uol.pgdoener.civicsage.index.document.DocumentReaderService;
+import de.uol.pgdoener.civicsage.index.exception.SplittingException;
 import de.uol.pgdoener.civicsage.index.exception.StorageException;
 import de.uol.pgdoener.civicsage.source.FileSource;
 import de.uol.pgdoener.civicsage.source.SourceService;
@@ -124,10 +125,16 @@ public class IndexService {
         documents = semanticSplitterService.process(documents);
         log.debug("Website split into {} semantic chunks", documents.size());
 
+        final int numDocumentsBeforeSplitting = documents.size();
         documents = documents.stream()
                 .flatMap(d -> textSplitter.split(d).stream())
                 .toList();
         log.debug("Split into {} chunks to fit context window", documents.size());
+
+        if (documents.isEmpty())
+            throw new SplittingException("Source does not have enough content to be indexed");
+        if (documents.size() < numDocumentsBeforeSplitting)
+            log.warn("There are less documents after splitting than before.");
 
         return documents;
     }

--- a/src/main/java/de/uol/pgdoener/civicsage/index/exception/SplittingException.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/exception/SplittingException.java
@@ -1,0 +1,9 @@
+package de.uol.pgdoener.civicsage.index.exception;
+
+public class SplittingException extends RuntimeException {
+
+    public SplittingException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
The `TextSplitter` has minimum amount of tokens for each document. If this causes all documents to disappear, status code 400 is returned. If some documents disappear, this is just logged. This might change in the future. Maybe we can merge documents in that case and split them somewhere else.