### PR TITLE
Wrap data in new resources for each document reader

### DIFF
--- a/src/main/java/de/uol/pgdoener/civicsage/index/IndexService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/IndexService.java
@@ -4,6 +4,7 @@ import de.uol.pgdoener.civicsage.business.dto.IndexFilesRequestInnerDto;
 import de.uol.pgdoener.civicsage.business.dto.IndexWebsiteRequestDto;
 import de.uol.pgdoener.civicsage.embedding.EmbeddingService;
 import de.uol.pgdoener.civicsage.index.document.DocumentReaderService;
+import de.uol.pgdoener.civicsage.index.exception.ReadFileException;
 import de.uol.pgdoener.civicsage.index.exception.StorageException;
 import de.uol.pgdoener.civicsage.source.FileSource;
 import de.uol.pgdoener.civicsage.source.SourceService;
@@ -15,8 +16,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.transformer.splitter.TextSplitter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 
@@ -56,7 +60,8 @@ public class IndexService {
         // Read the file from storage and process it
         String fileName = fileSource.getFileName();
         InputStream file = storageService.load(fileId).orElseThrow(() -> new StorageException("Could not load file from storage"));
-        List<Document> documents = documentReaderService.read(file, fileName);
+        Resource resource = toResource(file, fileName);
+        List<Document> documents = documentReaderService.read(resource, fileName);
         log.debug("Read {} documents from file: {}", documents.size(), fileName);
 
         documents = postProcessDocuments(documents);
@@ -70,6 +75,20 @@ public class IndexService {
         sourceService.save(fileSource);
 
         embeddingService.save(documents);
+    }
+
+    private Resource toResource(InputStream inputStream, String fileName) {
+        try {
+            byte[] data = inputStream.readAllBytes();
+            return new ByteArrayResource(data) {
+                @Override
+                public String getFilename() {
+                    return fileName;
+                }
+            };
+        } catch (IOException e) {
+            throw new ReadFileException("Could not read PDF file: " + fileName, e);
+        }
     }
 
 

--- a/src/main/java/de/uol/pgdoener/civicsage/index/document/DocumentReaderService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/document/DocumentReaderService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentReader;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 
 import java.io.FileNotFoundException;
@@ -21,7 +22,7 @@ public class DocumentReaderService {
 
     private final DocumentReaderFactory documentReaderFactory;
 
-    public List<Document> read(@NonNull InputStream file, @NonNull String fileName) {
+    public List<Document> read(@NonNull Resource file, @NonNull String fileName) {
         if (fileName.isBlank())
             throw new ReadFileException("File name is empty or null");
         final String fileEnding = fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase();

--- a/src/main/java/de/uol/pgdoener/civicsage/index/document/reader/PdfDocumentReader.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/document/reader/PdfDocumentReader.java
@@ -1,12 +1,15 @@
 package de.uol.pgdoener.civicsage.index.document.reader;
 
+import de.uol.pgdoener.civicsage.index.exception.ReadFileException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentReader;
 import org.springframework.ai.reader.pdf.PagePdfDocumentReader;
 import org.springframework.ai.reader.pdf.ParagraphPdfDocumentReader;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 
+import java.io.IOException;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -16,13 +19,29 @@ public class PdfDocumentReader implements DocumentReader {
 
     @Override
     public List<Document> get() {
+        byte[] data;
         try {
-            ParagraphPdfDocumentReader reader = new ParagraphPdfDocumentReader(resource);
+            data = resource.getContentAsByteArray();
+        } catch (IOException e) {
+            throw new ReadFileException("Could not read PDF file: " + resource.getFilename(), e);
+        }
+
+        try {
+            ParagraphPdfDocumentReader reader = new ParagraphPdfDocumentReader(constructRessourceFromData(data));
             return reader.read();
         } catch (RuntimeException e) {
-            PagePdfDocumentReader reader = new PagePdfDocumentReader(resource);
+            PagePdfDocumentReader reader = new PagePdfDocumentReader(constructRessourceFromData(data));
             return reader.read();
         }
+    }
+
+    private Resource constructRessourceFromData(byte[] data) {
+        return new ByteArrayResource(data) {
+            @Override
+            public String getFilename() {
+                return resource.getFilename();
+            }
+        };
     }
 
 }

--- a/src/main/java/de/uol/pgdoener/civicsage/index/document/reader/PdfDocumentReader.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/index/document/reader/PdfDocumentReader.java
@@ -1,15 +1,12 @@
 package de.uol.pgdoener.civicsage.index.document.reader;
 
-import de.uol.pgdoener.civicsage.index.exception.ReadFileException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.document.DocumentReader;
 import org.springframework.ai.reader.pdf.PagePdfDocumentReader;
 import org.springframework.ai.reader.pdf.ParagraphPdfDocumentReader;
-import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 
-import java.io.IOException;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -19,29 +16,13 @@ public class PdfDocumentReader implements DocumentReader {
 
     @Override
     public List<Document> get() {
-        byte[] data;
         try {
-            data = resource.getContentAsByteArray();
-        } catch (IOException e) {
-            throw new ReadFileException("Could not read PDF file: " + resource.getFilename(), e);
-        }
-
-        try {
-            ParagraphPdfDocumentReader reader = new ParagraphPdfDocumentReader(constructRessourceFromData(data));
+            ParagraphPdfDocumentReader reader = new ParagraphPdfDocumentReader(resource);
             return reader.read();
         } catch (RuntimeException e) {
-            PagePdfDocumentReader reader = new PagePdfDocumentReader(constructRessourceFromData(data));
+            PagePdfDocumentReader reader = new PagePdfDocumentReader(resource);
             return reader.read();
         }
-    }
-
-    private Resource constructRessourceFromData(byte[] data) {
-        return new ByteArrayResource(data) {
-            @Override
-            public String getFilename() {
-                return resource.getFilename();
-            }
-        };
     }
 
 }


### PR DESCRIPTION
If the ParagraphPdfDocumentReader fails, the resource has to be read again. Since it is based on an InputStream, this does not work. Now the data is read in advance and wrapped in a ByteArrayResource for each DocumentReader.