### PR TITLE
106 save metadata with sources in database

### DIFF
--- a/src/main/java/de/uol/pgdoener/civicsage/business/index/IndexService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/business/index/IndexService.java
@@ -4,6 +4,7 @@ import de.uol.pgdoener.civicsage.business.dto.IndexFilesRequestInnerDto;
 import de.uol.pgdoener.civicsage.business.dto.IndexWebsiteRequestDto;
 import de.uol.pgdoener.civicsage.business.embedding.EmbeddingService;
 import de.uol.pgdoener.civicsage.business.index.document.DocumentReaderService;
+import de.uol.pgdoener.civicsage.business.index.document.MetadataKeys;
 import de.uol.pgdoener.civicsage.business.index.exception.ReadFileException;
 import de.uol.pgdoener.civicsage.business.index.exception.SplittingException;
 import de.uol.pgdoener.civicsage.business.index.exception.StorageException;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static de.uol.pgdoener.civicsage.business.index.document.MetadataKeys.ADDITIONAL_PROPERTIES;
 import static de.uol.pgdoener.civicsage.business.index.document.MetadataKeys.FILE_ID;
@@ -73,6 +75,7 @@ public class IndexService {
 
         // Update the file source with the new model ID
         fileSource.getModels().add(modelID);
+        fileSource.getMetadata().putAll(getMetadataFromDocuments(documents));
         sourceService.save(fileSource);
 
         embeddingService.save(documents);
@@ -117,6 +120,7 @@ public class IndexService {
                 document.getMetadata().put(ADDITIONAL_PROPERTIES.getValue(), additionalProperties));
 
         websiteSource.getModels().add(modelID);
+        websiteSource.getMetadata().putAll(getMetadataFromDocuments(documents));
         sourceService.save(websiteSource);
 
         embeddingService.save(documents);
@@ -156,6 +160,29 @@ public class IndexService {
             log.warn("There are less documents after splitting than before.");
 
         return documents;
+    }
+
+    /**
+     * This method extracts the metadata from the first document in the list.
+     * It filters the metadata keys to only include those that are exposed via the API.
+     *
+     * @param documents the list of documents to extract metadata from
+     * @return a map of metadata keys and values that are exposed via the API
+     */
+    private Map<String, Object> getMetadataFromDocuments(List<Document> documents) {
+        final Map<String, Object> metadataOfFirstDocument = documents.getFirst().getMetadata();
+        Map<String, Object> exposedMetadata = MetadataKeys.EXPOSED_KEYS.stream()
+                .filter(k -> metadataOfFirstDocument.containsKey(k.getValue()))
+                .collect(Collectors.toMap(
+                        MetadataKeys::getValue,
+                        v -> metadataOfFirstDocument.get(v.getValue())
+                ));
+        if (metadataOfFirstDocument.containsKey(ADDITIONAL_PROPERTIES.getValue()))
+            exposedMetadata.put(
+                    ADDITIONAL_PROPERTIES.getValue(),
+                    metadataOfFirstDocument.get(ADDITIONAL_PROPERTIES.getValue())
+            );
+        return exposedMetadata;
     }
 
 }

--- a/src/main/java/de/uol/pgdoener/civicsage/business/index/IndexService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/business/index/IndexService.java
@@ -104,7 +104,7 @@ public class IndexService {
                 new HashMap<>() : indexWebsiteRequestDto.getAdditionalProperties();
 
         WebsiteSource websiteSource = sourceService.getWebsiteSourceByUrl(url)
-                .orElse(new WebsiteSource(null, url, new ArrayList<>()));
+                .orElse(new WebsiteSource(null, url, new ArrayList<>(), new HashMap<>()));
         if (websiteSource.getModels().contains(modelID)) {
             throw new SourceCollisionException("Website is already indexed for current model!");
         }

--- a/src/main/java/de/uol/pgdoener/civicsage/business/index/IndexService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/business/index/IndexService.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static de.uol.pgdoener.civicsage.business.index.document.MetadataKeys.ADDITIONAL_PROPERTIES;
@@ -172,10 +173,11 @@ public class IndexService {
     private Map<String, Object> getMetadataFromDocuments(List<Document> documents) {
         final Map<String, Object> metadataOfFirstDocument = documents.getFirst().getMetadata();
         Map<String, Object> exposedMetadata = MetadataKeys.EXPOSED_KEYS.stream()
-                .filter(k -> metadataOfFirstDocument.containsKey(k.getValue()))
+                .map(MetadataKeys::getValue)
+                .filter(metadataOfFirstDocument::containsKey)
                 .collect(Collectors.toMap(
-                        MetadataKeys::getValue,
-                        v -> metadataOfFirstDocument.get(v.getValue())
+                        Function.identity(),
+                        metadataOfFirstDocument::get
                 ));
         if (metadataOfFirstDocument.containsKey(ADDITIONAL_PROPERTIES.getValue()))
             exposedMetadata.put(

--- a/src/main/java/de/uol/pgdoener/civicsage/business/index/document/MetadataKeys.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/business/index/document/MetadataKeys.java
@@ -3,6 +3,9 @@ package de.uol.pgdoener.civicsage.business.index.document;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Getter
 @RequiredArgsConstructor
 public enum MetadataKeys {
@@ -16,6 +19,10 @@ public enum MetadataKeys {
     URL("url", true),
     ADDITIONAL_PROPERTIES("additional_properties", false), // this is marked as internal, but is available in filter expression using "additional_properties."
     STARTUP_DOCUMENT("startup_document", false);
+
+    public static final List<MetadataKeys> EXPOSED_KEYS = Arrays.stream(MetadataKeys.values())
+            .filter(MetadataKeys::isExposed)
+            .toList();
 
     /**
      * The key used in the metadata map stored in the {@link org.springframework.ai.vectorstore.VectorStore}

--- a/src/main/java/de/uol/pgdoener/civicsage/business/search/FilterExpressionValidator.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/business/search/FilterExpressionValidator.java
@@ -8,8 +8,8 @@ import org.springframework.ai.vectorstore.filter.Filter;
 import org.springframework.ai.vectorstore.filter.FilterExpressionTextParser;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
 import java.util.List;
+
 
 /**
  * This class validates filter expressions based on exposed metadata keys ({@link MetadataKeys}) and
@@ -20,8 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FilterExpressionValidator {
 
-    private static final List<String> validMetadataKeys = Arrays.stream(MetadataKeys.values())
-            .filter(MetadataKeys::isExposed)
+    private static final List<String> validMetadataKeys = MetadataKeys.EXPOSED_KEYS.stream()
             .map(MetadataKeys::getValue)
             .toList();
 

--- a/src/main/java/de/uol/pgdoener/civicsage/business/source/FileSource.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/business/source/FileSource.java
@@ -4,8 +4,12 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Entity
@@ -25,5 +29,9 @@ public class FileSource {
 
     @ElementCollection(fetch = FetchType.EAGER)
     private List<String> models;
+
+    // https://www.baeldung.com/hibernate-persist-json-object#the-jdbctypecode-annotation
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Map<String, Object> metadata = new HashMap<>();
 
 }

--- a/src/main/java/de/uol/pgdoener/civicsage/business/source/WebsiteSource.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/business/source/WebsiteSource.java
@@ -4,8 +4,12 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Entity
@@ -23,5 +27,9 @@ public class WebsiteSource {
 
     @ElementCollection(fetch = FetchType.EAGER)
     private List<String> models;
+
+    // https://www.baeldung.com/hibernate-persist-json-object#the-jdbctypecode-annotation
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Map<String, Object> metadata = new HashMap<>();
 
 }

--- a/src/main/java/de/uol/pgdoener/civicsage/business/storage/FileService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/business/storage/FileService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -32,7 +33,7 @@ public class FileService {
             String hash = fileHashingService.hash(iss.getInputStream());
             sourceService.verifyFileHashNotIndexed(hash);
             UUID objectID = storeInStorage(iss);
-            sourceService.save(new FileSource(objectID, fileName, hash, List.of()));
+            sourceService.save(new FileSource(objectID, fileName, hash, List.of(), Map.of()));
             log.info("File {} uploaded successfully with ID {}", fileName, objectID);
             return objectID;
         } catch (IOException e) {


### PR DESCRIPTION
This PR saves metadata associated with sources in the database. The saved metadata is retrieved from the documents after all processing is completed. This ensures that metadata added at different places in the indexing process is captured. It is assumed that all metadata relevant to be saved in the database is present in all documents.

Metadata is saved as a JSON blob in the database.