### PR TITLE
Return status code 503 Service Unavailable when search fails due to rate limit

### DIFF
--- a/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import de.uol.pgdoener.civicsage.business.index.exception.SplittingException;
 import de.uol.pgdoener.civicsage.business.index.exception.StorageException;
 import de.uol.pgdoener.civicsage.business.search.exception.FilterExpressionException;
 import de.uol.pgdoener.civicsage.business.search.exception.NotEnoughResultsAvailableException;
+import de.uol.pgdoener.civicsage.business.search.exception.SearchRateLimitException;
 import de.uol.pgdoener.civicsage.business.source.exception.HashingException;
 import de.uol.pgdoener.civicsage.business.source.exception.SourceCollisionException;
 import de.uol.pgdoener.civicsage.business.source.exception.SourceNotFoundException;
@@ -28,6 +29,13 @@ import java.util.Map;
 @Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(SearchRateLimitException.class)
+    public ResponseEntity<Object> handleSearchRateLimitException(SearchRateLimitException ex) {
+        ErrorResponse errorResponse = ErrorResponse.create(ex, HttpStatus.SERVICE_UNAVAILABLE, ex.getMessage());
+        log.debug("SearchRateLimitException: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(errorResponse.getBody());
+    }
 
     @ExceptionHandler(SplittingException.class)
     public ResponseEntity<Object> handleSplittingException(SplittingException ex) {

--- a/src/main/java/de/uol/pgdoener/civicsage/business/search/exception/SearchRateLimitException.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/business/search/exception/SearchRateLimitException.java
@@ -1,0 +1,4 @@
+package de.uol.pgdoener.civicsage.business.search.exception;
+
+public class SearchRateLimitException extends RuntimeException {
+}


### PR DESCRIPTION
- Catching NonTransientAiException from failed search.
- If the search failed due to a 429 status code from a request, the message from Spring AI always starts with "HTTP 429". This is used to determine that  the rate limit has been hit.
- Added custom SearchRateLimitException to throw in that case.
- The GlobalExceptionHandler catches it and returns 503 Service Unavailable.