### PR TITLE
Index requests are no longer run in separate thread.

### DIFF
--- a/src/main/java/de/uol/pgdoener/civicsage/api/controller/IndexController.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/api/controller/IndexController.java
@@ -11,8 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 @Slf4j
 @Component
@@ -20,29 +18,24 @@ import java.util.concurrent.Executors;
 public class IndexController implements IndexApiDelegate {
 
     private final IndexService indexService;
-    private final ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
 
     @Override
     public ResponseEntity<Void> indexFiles(List<IndexFilesRequestInnerDto> requests) {
-        executorService.submit(() -> {
-            log.info("Received {} files to index", requests.size());
-            for (IndexFilesRequestInnerDto request : requests) {
-                log.info("Indexing file {}", request.getTitle());
-                indexService.indexFile(request, EmbeddingPriority.HIGH);
-                log.info("File {} indexed successfully", request.getTitle());
-            }
-        });
+        log.info("Received {} files to index", requests.size());
+        for (IndexFilesRequestInnerDto request : requests) {
+            log.info("Indexing file {}", request.getTitle());
+            indexService.indexFile(request, EmbeddingPriority.HIGH);
+            log.info("File {} indexed successfully", request.getTitle());
+        }
 
         return ResponseEntity.accepted().build();
     }
 
     @Override
     public ResponseEntity<Void> indexWebsite(IndexWebsiteRequestDto indexWebsiteRequestDto) {
-        executorService.submit(() -> {
-            log.info("Indexing website {}", indexWebsiteRequestDto.getUrl());
-            indexService.indexURL(indexWebsiteRequestDto, EmbeddingPriority.HIGH);
-            log.info("Website {} indexed successfully", indexWebsiteRequestDto.getUrl());
-        });
+        log.info("Indexing website {}", indexWebsiteRequestDto.getUrl());
+        indexService.indexURL(indexWebsiteRequestDto, EmbeddingPriority.HIGH);
+        log.info("Website {} indexed successfully", indexWebsiteRequestDto.getUrl());
 
         return ResponseEntity.accepted().build();
     }


### PR DESCRIPTION
- This allows exceptions thrown while creating the documents to be thrown to give the user feedback.
- Before this all request were "accepted" regardless of whether the documents could be created.