### PR TITLE
162 also keep track of chats using indexed files and revert to temporary if still used after source deletion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>
-                                https://raw.githubusercontent.com/uol-esis/CivicSage-OpenAPI/241fd1464e34ac234ce5f3d985fcd4a68ea97250/openapi.yaml
+                                https://raw.githubusercontent.com/uol-esis/CivicSage-OpenAPI/v0.6.1/openapi.yaml
                             </inputSpec>
                             <generatorName>spring</generatorName>
                             <apiPackage>de.uol.pgdoener.civicsage.api</apiPackage>

--- a/src/main/java/de/uol/pgdoener/civicsage/business/storage/FileService.java
+++ b/src/main/java/de/uol/pgdoener/civicsage/business/storage/FileService.java
@@ -105,7 +105,7 @@ public class FileService {
                         existing.getModels(),
                         existing.getMetadata(),
                         false,
-                        Set.of() // We do not care about chats using permanent files. So we clear the list here.
+                        existing.getUsedByChats()
                 );
                 sourceService.save(updated);
                 return existing.getObjectStorageId();


### PR DESCRIPTION
- The set of chats using a file is now kept when it is marked as permanent.
- If the file is deleted when it is permanent and still used by chats, it is marked as temporary.
- If the chat is deleted, the list of chats using associated files is correctly updated